### PR TITLE
Rename intentToRetail to intentToRetain in RequestItem struct

### DIFF
--- a/Sources/MdocDataTransfer18013/MdocHelpers.swift
+++ b/Sources/MdocDataTransfer18013/MdocHelpers.swift
@@ -176,7 +176,7 @@ public class MdocHelpers {
 				}
 				if itemsToAdd.count > 0 {
 					nsItemsToAdd[reqNamespace] = itemsToAdd
-					validReqItemsNsDict[reqNamespace] = itemsToAdd.map { RequestItem(elementIdentifier: $0.elementIdentifier, intentToRetail: docReq?.itemsRequest.requestNameSpaces.nameSpaces[reqNamespace]?.dataElements[$0.elementIdentifier] ?? false, isOptional: false) }
+					validReqItemsNsDict[reqNamespace] = itemsToAdd.map { RequestItem(elementIdentifier: $0.elementIdentifier, intentToRetain: docReq?.itemsRequest.requestNameSpaces.nameSpaces[reqNamespace]?.dataElements[$0.elementIdentifier] ?? false, isOptional: false) }
 				}
 				let errorItemsSet = itemsReqSet.subtracting(itemsSet)
 				if errorItemsSet.count > 0 {

--- a/Sources/MdocDataTransfer18013/RequestItem.swift
+++ b/Sources/MdocDataTransfer18013/RequestItem.swift
@@ -16,18 +16,18 @@ limitations under the License.
 import Foundation
 
 public struct RequestItem: Sendable {
-    public init(elementIdentifier: String, intentToRetail: Bool? = nil, isOptional: Bool? = nil) {
+    public init(elementIdentifier: String, intentToRetain: Bool? = nil, isOptional: Bool? = nil) {
         self.elementIdentifier = elementIdentifier
-        self.intentToRetail = intentToRetail
+        self.intentToRetain = intentToRetain
         self.isOptional = isOptional
     }
     public init(elementIdentifier: String) {
         self.elementIdentifier = elementIdentifier
-        self.intentToRetail = nil
+        self.intentToRetain = nil
         self.isOptional = nil
     }
 
     public let elementIdentifier: String
-    public let intentToRetail: Bool?
+    public let intentToRetain: Bool?
     public let isOptional: Bool?
 }


### PR DESCRIPTION
Update the `RequestItem` struct to rename the `intentToRetail` property to `intentToRetain` and adjust initializers accordingly.