### PR TITLE
Update RequestItem initialization to allow optional items

### DIFF
--- a/Sources/MdocDataTransfer18013/MdocHelpers.swift
+++ b/Sources/MdocDataTransfer18013/MdocHelpers.swift
@@ -176,7 +176,7 @@ public class MdocHelpers {
 				}
 				if itemsToAdd.count > 0 {
 					nsItemsToAdd[reqNamespace] = itemsToAdd
-					validReqItemsNsDict[reqNamespace] = itemsToAdd.map { RequestItem(elementIdentifier: $0.elementIdentifier, intentToRetain: docReq?.itemsRequest.requestNameSpaces.nameSpaces[reqNamespace]?.dataElements[$0.elementIdentifier] ?? false, isOptional: false) }
+					validReqItemsNsDict[reqNamespace] = itemsToAdd.map { RequestItem(elementIdentifier: $0.elementIdentifier, intentToRetain: docReq?.itemsRequest.requestNameSpaces.nameSpaces[reqNamespace]?.dataElements[$0.elementIdentifier], isOptional: nil) }
 				}
 				let errorItemsSet = itemsReqSet.subtracting(itemsSet)
 				if errorItemsSet.count > 0 {


### PR DESCRIPTION
Modify the `MdocHelpers` to set `isOptional` to `nil` during `RequestItem` initialization, enabling better handling of optional items.