### PR TITLE
Refactor RequestItem structure for element paths and multiple display names

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*.swift]
+indent_style = tab
+indent_size = 4
+tab_width = 4
+end_of_line = crlf
+insert_final_newline = false
+max_line_length = 500	
+trim_trailing_whitespace = true

--- a/Sources/MdocDataTransfer18013/RequestItem.swift
+++ b/Sources/MdocDataTransfer18013/RequestItem.swift
@@ -17,37 +17,52 @@ import Foundation
 
 /// A structure representing a request item for data transfer.
 public struct RequestItem: Equatable, Hashable, Sendable {
-		public init(elementIdentifier: String, displayName: String?, intentToRetain: Bool? = nil, isOptional: Bool? = nil) {
-				self.elementIdentifier = elementIdentifier
-				self.displayName = displayName
-				self.intentToRetain = intentToRetain
-				self.isOptional = isOptional
-		}
-	
-		public init(elementIdentifier: String) {
-				self.elementIdentifier = elementIdentifier
-				self.displayName = nil
-				self.intentToRetain = nil
-				self.isOptional = nil
-		}
+	public init(elementPath: [String], displayNames: [String?], intentToRetain: Bool? = nil, isOptional: Bool? = nil) {
+		self.elementPath = elementPath
+		self.displayNames = displayNames
+		self.intentToRetain = intentToRetain
+		self.isOptional = isOptional
+	}
 
-		/// A unique identifier for the data element.
-		/// This identifier is used to distinguish between different elements within the data transfer process.
-		public let elementIdentifier: String
-	  // display name
-		public let displayName: String?
-		/// Indicates whether the mdoc verifier intends to retain the received data element
-		public let intentToRetain: Bool?
-		/// Indicates whether the data element is optional.
-		/// false or nil value of the property indicates the field is required
-		public let isOptional: Bool?
+	/// A unique identifier for the data element.
+	/// This element path is used to distinguish between different elements within the data transfer process.
+	public let elementPath: [String]
 
-		//implementation of Equatable and Hashable
-		public static func == (lhs: RequestItem, rhs: RequestItem) -> Bool {
-				return lhs.elementIdentifier == rhs.elementIdentifier
-		}
+	/// A string representation of the element path
+	public var elementIdentifier: String {
+		elementPath.joined(separator: ".")
+	}
+	/// display names of the component paths (currently only the root display name is not-nil)
+	public let displayNames: [String?]
 
-		public func hash(into hasher: inout Hasher) {
-				hasher.combine(elementIdentifier)
-		}
+	/// Indicates whether the mdoc verifier intends to retain the received data element
+	public let intentToRetain: Bool?
+	/// Indicates whether the data element is optional.
+	/// false or nil value of the property indicates the field is required
+	public let isOptional: Bool?
+
+	///implementation of Equatable and Hashable
+	public static func == (lhs: RequestItem, rhs: RequestItem) -> Bool {
+		return lhs.elementPath == rhs.elementPath
+	}
+
+	public func hash(into hasher: inout Hasher) {
+		hasher.combine(elementPath)
+	}
+}
+
+extension RequestItem {
+	public init(elementPath: [String]) {
+		self.init(elementPath: elementPath, displayNames: Array(repeating: nil, count: elementPath.count), intentToRetain: nil, isOptional: nil)
+	}
+
+	public init(elementIdentifier: String) {
+		let elementPath = elementIdentifier.components(separatedBy: ".")
+		self.init(elementPath: elementPath, displayNames: Array(repeating: nil, count: elementPath.count), intentToRetain: nil, isOptional: nil)
+	}
+
+	public init(elementIdentifier: String, displayName: String?, intentToRetain: Bool? = nil, isOptional: Bool? = nil) {
+		self.init(elementPath: elementIdentifier.components(separatedBy: "."), displayNames: [displayName], intentToRetain: intentToRetain, isOptional: isOptional)
+	}
+
 }


### PR DESCRIPTION
Enhance the RequestItem structure to support element paths and multiple display names, improving data transfer representation. 