### PR TITLE
Use 16byte for BLE service UUID instead of 16bits

### DIFF
--- a/Sources/MdocDataTransfer18013/BLETransfer/MdocGATTServer.swift
+++ b/Sources/MdocDataTransfer18013/BLETransfer/MdocGATTServer.swift
@@ -168,20 +168,17 @@ public class MdocGattServer: @unchecked Sendable, ObservableObject {
 	}
 	
 	func start() {
-		guard !isPreview && !isInErrorState else { 
+		guard !isPreview && !isInErrorState else {
 			logger.info("Current status is \(status)")
 			return
 		}
 		if peripheralManager.state == .poweredOn {
 			logger.info("Peripheral manager powered on")
 			error = nil
-			// get the BLE UUID from the device engagement and truncate it to the first 4 characters (short UUID)
-			guard var uuid = deviceEngagement!.ble_uuid else {
+			guard let uuid = deviceEngagement?.ble_uuid else {
 				logger.error("BLE initialization error")
 				return
 			}
-			let index = uuid.index(uuid.startIndex, offsetBy: 4)
-			uuid = String(uuid[index...].prefix(4)).uppercased()
 			buildServices(uuid: uuid)
 			let advertisementData: [String: Any] = [ CBAdvertisementDataServiceUUIDsKey: [CBUUID(string: uuid)], CBAdvertisementDataLocalNameKey: uuid ]
 			// advertise the peripheral with the short UUID


### PR DESCRIPTION
Following chapter "8.3.3.1.1.3 Connection setup" of ISO18013-5 first and second edition:
> "The UUID's used shall be 16-byte UUIDs that are unique for the transaction. The Peripheral device shall broadcast the service with the UUID as received or sent during device engagement in the advertising packet."

But looking at the implementation we observe:

> // get the BLE UUID from the device engagement and truncate it to the first 4 characters (short UUID)
> guard var uuid = deviceEngagement!.ble_uuid else {
>	logger.error("BLE initialization error")
>	return
> }
> let index = uuid.index(uuid.startIndex, offsetBy: 4)
> uuid = String(uuid[index...].prefix(4)).uppercased()
> buildServices(uuid: uuid)

This results in a "short UUID" of 16bits instead of 128bits (or 16-bytes like mentioned in the ISO document).
This is not conform the requirements and makes this sdk not usable for interoperability if not resolved.