### PR TITLE
Update package dependencies for eudi-lib-ios-iso18013 libraries

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "2980f80ec428be8c3b1a703b19904e5ab1bcf8ab0525630b83880fca1c1179d5",
+  "originHash" : "1877ed8fd3a1f4e441d31132f6ce31d8b97900e9575af6b24a0c04d21da345ee",
   "pins" : [
     {
       "identity" : "eudi-lib-ios-iso18013-data-model",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "4dd729db2bacd350dedcb68c252d7650fbad59af",
-        "version" : "0.6.0"
+        "revision" : "a3252e7d1d764ae51d3f78ee184cef77cc7f90b7",
+        "version" : "0.6.2"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git",
       "state" : {
-        "revision" : "ab0d16d2edad0c17147a7392322fa30d6dbe502c",
-        "version" : "0.5.0"
+        "revision" : "41aecf3edc5a5b84ba7c022d88891ae92bf926a3",
+        "version" : "0.5.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["MdocDataTransfer18013"]),
     ],
     dependencies: [
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git", exact: "0.5.0"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git", exact: "0.5.1"),
 	],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
Upgrade the eudi-lib-ios-iso18013-data-model to version 0.6.2 and eudi-lib-ios-iso18013-security to version 0.5.1 to ensure compatibility and access to the latest features.