### PR TITLE
fix: mark action closures as @MainActor to resolve data race warnings

### DIFF
--- a/Sources/MdocDataTransfer18013/MdocHelpers.swift
+++ b/Sources/MdocDataTransfer18013/MdocHelpers.swift
@@ -315,7 +315,7 @@ public class MdocHelpers {
 	///   - vc: The view controller that will present the settings
 	///   - action: The action to perform
 	@MainActor
-	public static func checkBleAccess(_ vc: UIViewController, action: @escaping ()->Void) {
+	public static func checkBleAccess(_ vc: UIViewController, action: @MainActor @escaping () -> Void) {
 		switch CBManager.authorization {
 		case .denied:
 			// "Denied, request permission from settings"
@@ -324,9 +324,9 @@ public class MdocHelpers {
 			logger.warning("Restricted, device owner must approve")
 		case .allowedAlways:
 			// "Authorized, proceed"
-			DispatchQueue.main.async { action() }
+			action()
 		case .notDetermined:
-			DispatchQueue.main.async { action() }
+			action()
 		@unknown default:
 			logger.info("Unknown authorization status")
 		}
@@ -337,7 +337,7 @@ public class MdocHelpers {
 	///   - vc:  The view controller that will present the settings
 	///   - action: The action to perform
 	@MainActor
-	public static func checkCameraAccess(_ vc: UIViewController, action: @escaping ()->Void) {
+	public static func checkCameraAccess(_ vc: UIViewController, action: @MainActor @escaping () -> Void) {
 		switch AVCaptureDevice.authorizationStatus(for: .video) {
 		case .denied:
 			// "Denied, request permission from settings"
@@ -346,11 +346,11 @@ public class MdocHelpers {
 			logger.warning("Restricted, device owner must approve")
 		case .authorized:
 			// "Authorized, proceed"
-			DispatchQueue.main.async { action() }
+			action()
 		case .notDetermined:
 			AVCaptureDevice.requestAccess(for: .video) { success in
 				if success {
-					DispatchQueue.main.async { action() }
+					Task { @MainActor in action() }
 				} else {
 					logger.info("Permission denied")
 				}


### PR DESCRIPTION
## Summary

- Mark `action` parameter as `@MainActor` in `checkBleAccess` and `checkCameraAccess` to fix Swift strict concurrency warnings: _"Sending 'action' risks causing data races"_ and _"Capture of 'action' with non-Sendable type '() -> Void' in a '@Sendable' closure"_
- Remove redundant `DispatchQueue.main.async` calls in cases where the function is already executing on `@MainActor`
- Replace `DispatchQueue.main.async { action() }` in the `AVCaptureDevice.requestAccess` callback with `Task { @MainActor in action() }` since that callback is delivered on a background thread

## Test plan

- [ ] Build succeeds with no data race warnings or errors in `MdocHelpers.swift`
- [ ] BLE permission flow tested: `.allowedAlways` and `.notDetermined` cases invoke `action` correctly on the main thread
- [ ] Camera permission flow tested: `.authorized` and `.notDetermined` (both granted and denied) cases behave correctly