### PR TITLE
Update dependencies to version 0.11.3 for data model and security libraries

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "f3f5f05f95a81a381119263f2b8456c0d39eee514732db308fa713807bbba301",
+  "originHash" : "1cce873b17a37258164b263a9b09964a389df543b23ca7e8b631bc51393c0748",
   "pins" : [
     {
       "identity" : "eudi-lib-ios-iso18013-data-model",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "e489425f82effbac1f4c260bfa1c05ba64fd8f62",
-        "version" : "0.11.2"
+        "revision" : "46891644987328066ad6a047bf46959db2462c61",
+        "version" : "0.11.3"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git",
       "state" : {
-        "revision" : "ae9d029a05be069f79deba8d714aa3581aefc5f7",
-        "version" : "0.11.2"
+        "revision" : "dcff5f72e3642a5571ac8b5b9c42edb002f9ac7e",
+        "version" : "0.11.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["MdocDataTransfer18013"]),
     ],
     dependencies: [
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git", exact: "0.11.2"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git", exact: "0.11.3"),
 	],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
Update the data model and security libraries to version 0.11.3 to ensure compatibility and incorporate the latest features and fixes.