### PR TITLE
Exclude BLE peripheral code from watchOS platform

### DIFF
--- a/Sources/MdocDataTransfer18013/BLETransfer/MdocGATTServer.swift
+++ b/Sources/MdocDataTransfer18013/BLETransfer/MdocGATTServer.swift
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+#if !os(watchOS)
 import Foundation
 import SwiftCBOR
 import CoreBluetooth
@@ -303,3 +303,4 @@ public class MdocGattServer: @unchecked Sendable, MdocBleTransport {
 
 }
 
+#endif	

--- a/Sources/MdocDataTransfer18013/BLETransfer/ServiceCharacteristics.swift
+++ b/Sources/MdocDataTransfer18013/BLETransfer/ServiceCharacteristics.swift
@@ -19,6 +19,7 @@ import Foundation
 import CoreBluetooth
 import SwiftCBOR
 
+#if !os(watchOS)
 extension MdocGattServer {
 	/// mdoc service characteristic definitions (mdoc is the GATT server)
 	public enum MdocServiceCharacteristic: String, CustomStringConvertible, Sendable {
@@ -38,6 +39,7 @@ extension MdocGattServer {
 		var uuid: CBUUID { CBUUID(string: rawValue) }
 	}
 }
+#endif
 
 extension MdocGattCentral {
 	/// mdoc service characteristic definitions (mdoc is the GATT server)

--- a/Sources/MdocDataTransfer18013/MdocHelpers.swift
+++ b/Sources/MdocDataTransfer18013/MdocHelpers.swift
@@ -39,7 +39,7 @@ public class MdocHelpers {
 			"key": Self.errorNoDocumentsDescriptionKey,
 			"%s": docType
 		]
-		return NSError(domain: "\(MdocGattServer.self)", code: 0, userInfo: userInfo)
+		return NSError(domain: "MdocHelpers", code: 0, userInfo: userInfo)
 	}
 
 	public static func makeError(code: ErrorCode, str: String? = nil) -> NSError {
@@ -49,7 +49,7 @@ public class MdocHelpers {
 			NSLocalizedDescriptionKey: errorMessage,
 			"key": code.description
 		]
-		return NSError(domain: "\(MdocGattServer.self)", code: code.rawValue, userInfo: userInfo)
+		return NSError(domain: "MdocHelpers", code: code.rawValue, userInfo: userInfo)
 	}
 
 	/// Get the session data to send to the reader. The session data is encrypted using the session encryption object


### PR DESCRIPTION
Remove BLE peripheral server code from the watchOS build to ensure compatibility with the platform.

Fixes #106