### PR TITLE
Update eudi-lib-ios-iso18013-security dependency to version 0.20.3

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "b16c69489c44c95d1d07c528c951e49bc604d3ea89d2050648a13e22f510c595",
+  "originHash" : "e399969a8631b94f61cb569a298dba4ff933d1276543e42f566a01eb1e10fac5",
   "pins" : [
     {
       "identity" : "eudi-lib-ios-iso18013-data-model",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-data-model.git",
       "state" : {
-        "revision" : "c72b2e622f987565927b67e67b754779df7b7e84",
-        "version" : "0.20.1"
+        "revision" : "fa8854523d7e71aba87de0f2540afc74adbb15bc",
+        "version" : "0.20.2"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git",
       "state" : {
-        "revision" : "9e200d0931ecb14e20bff61b3fee2533d8cadb90",
-        "version" : "0.20.2"
+        "revision" : "71e2f617abec86561e5b33f764102ee0cd02ae96",
+        "version" : "0.20.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["MdocDataTransfer18013"]),
     ],
     dependencies: [
-		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git", exact: "0.20.2"),
+		.package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-iso18013-security.git", exact: "0.20.3"),
 		.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
     targets: [


### PR DESCRIPTION
Upgrade the eudi-lib-ios-iso18013-security dependency to the latest version for improved functionality and security. This change ensures compatibility with the updated library version.